### PR TITLE
Unify floats and integers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -43,7 +43,7 @@ impl Expr {
 #[derive(Debug, Clone)]
 pub enum Atom {
     Id(String),
-    Int(i64),
+    Number(f64),
     StringAtom(String),
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -112,7 +112,7 @@ pub fn eval_list(list: &[Expr], env: Rc<Env>) -> Rc<LispValue> {
 pub fn eval_atom(atom: &Atom, env: Rc<Env>) -> Rc<LispValue> {
     debug!("eval_atom {:?}", atom);
     match atom {
-        Atom::Int(num) => Rc::new(LispValue::Int(*num)),
+        Atom::Number(num) => Rc::new(LispValue::Number(*num)),
         Atom::StringAtom(s) => Rc::new(LispValue::StringValue(s.to_string())),
         Atom::Id(id) => match id.as_str() {
             "true" => Rc::new(LispValue::Bool(Bool::True)),
@@ -121,6 +121,7 @@ pub fn eval_atom(atom: &Atom, env: Rc<Env>) -> Rc<LispValue> {
                 .get(&id)
                 .unwrap_or_else(|| panic!("Symbol {} not found", id)),
         },
+        // Atom::Float(f) => Rc::new(LispValue::Float(*f)),
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -121,7 +121,6 @@ pub fn eval_atom(atom: &Atom, env: Rc<Env>) -> Rc<LispValue> {
                 .get(&id)
                 .unwrap_or_else(|| panic!("Symbol {} not found", id)),
         },
-        // Atom::Float(f) => Rc::new(LispValue::Float(*f)),
     }
 }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -23,7 +23,9 @@ pub Expr: Expr = {
     },
 
     "(" <l:List> ")" => Expr::List(l),
+
     <a:Atom> => Expr::Atom(a),
+
 };
 
 pub List: Vec<Expr> = {
@@ -33,12 +35,11 @@ pub List: Vec<Expr> = {
 pub Atom: Atom = {
     <s:Op> => Atom::Id(s),
     <s:StringLiteral> => Atom::StringAtom(s),
-    //TODO float
-    <s:Number> => Atom::Int(s),
+    <s:Number> => Atom::Number(s),
     <s:Id> => Atom::Id(s),
 }
 
 Op: String = <s:r"[+\-*/=><]"> => s.to_string();
 Id: String = <s:r"[[:alpha:]][\d\w\-_]*\??"> => s.to_string();
-Number: i64 =  <s:r"[0-9]+"> => i64::from_str(s).unwrap();
+Number: f64 =  <s:r"(\-)?[0-9]+(\.[0-9]+)?"> => f64::from_str(s).unwrap();
 StringLiteral: String = <s:r#""(?:[^"\\]|\\.)*""#> => s[1..(s.len() - 1)].to_string();

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -4,9 +4,9 @@ use std::rc::Rc;
 use crate::lisp_value::{Bool, LispValue};
 
 pub fn add(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
-    let res = arguments.iter().fold(0, |acc, x| acc + x.unwrap_number());
-
-    Rc::new(LispValue::Int(res))
+    let res = arguments.iter().fold(0.0, |acc, x| acc + x.unwrap_number());
+    
+    Rc::new(LispValue::Number(res))
 }
 
 pub fn sub(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
@@ -17,7 +17,7 @@ pub fn sub(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
         .skip(1)
         .fold(*first, |acc, x| acc - x.unwrap_number());
 
-    Rc::new(LispValue::Int(res))
+    Rc::new(LispValue::Number(res))
 }
 
 pub fn eq(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -5,7 +5,7 @@ use crate::lisp_value::{Bool, LispValue};
 
 pub fn add(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
     let res = arguments.iter().fold(0.0, |acc, x| acc + x.unwrap_number());
-    
+
     Rc::new(LispValue::Number(res))
 }
 

--- a/src/lisp_value.rs
+++ b/src/lisp_value.rs
@@ -12,7 +12,7 @@ pub enum LispValue {
     Nill,
     #[allow(dead_code)]
     Id(String),
-    Int(i64),
+    Number(f64),
     Bool(Bool),
     Intrinsic(fn(&[Rc<LispValue>]) -> Rc<LispValue>),
     Func(Func),
@@ -20,9 +20,9 @@ pub enum LispValue {
 }
 
 impl LispValue {
-    pub fn unwrap_number(&self) -> &i64 {
+    pub fn unwrap_number(&self) -> &f64 {
         match self {
-            LispValue::Int(ref num) => num,
+            LispValue::Number(ref num) => num,
             _ => panic!("BBBB"),
         }
     }
@@ -34,7 +34,7 @@ impl PartialEq for LispValue {
 
         match (self, other) {
             (LispValue::Nill, LispValue::Nill) => true,
-            (Int(ref n1), Int(ref n2)) => n1 == n2,
+            (Number(ref n1), Number(ref n2)) => n1 == n2,
             (Id(ref id1), Id(ref id2)) => *id1 == *id2,
             (Bool(ref bool1), Bool(ref bool2)) => bool1 == bool2,
             (StringValue(ref string1), StringValue(ref string2)) => string1 == string2,
@@ -50,7 +50,7 @@ impl Ord for LispValue {
         use self::LispValue::*;
 
         match (self, other) {
-            (Int(ref n1), Int(ref n2)) => n1.cmp(n2),
+            (Number(ref n1), Number(ref n2)) => n1.partial_cmp(n2).unwrap(),
             // TODO is this the right thing to do?
             _ => Ordering::Equal,
         }
@@ -61,7 +61,7 @@ impl PartialOrd for LispValue {
     fn partial_cmp(&self, other: &LispValue) -> Option<Ordering> {
         use self::LispValue::*;
         match (self, other) {
-            (Int(ref n1), Int(ref n2)) => Some(n1.cmp(n2)),
+            (Number(ref n1), Number(ref n2)) => Some(n1.partial_cmp(n2).unwrap()),
             // TODO is this the right thing to do?
             _ => None,
         }
@@ -74,7 +74,7 @@ impl fmt::Debug for LispValue {
             LispValue::Nill => write!(f, "Nill"),
             LispValue::Intrinsic(_) => write!(f, "intrinsic"),
             LispValue::Func(func) => write!(f, "#func {}", func.get_name()),
-            LispValue::Int(num) => write!(f, "{}", num),
+            LispValue::Number(num) => write!(f, "{}", num),
             LispValue::Id(str) => write!(f, "{}", str),
             LispValue::Bool(lisp_bool) => match lisp_bool {
                 Bool::True => write!(f, "true"),


### PR DESCRIPTION
Today we worked with @lspigariol to unify the integers with the floats to have only 1 number type. This will simplify the number of operations and level of detail required when dealing with numbers. 
