### PR TITLE
Run GitHub Actions only on pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push]
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
This PR modifies the workflow to only run on PRs instead of pushes, saving precious seconds (or minutes) from our monthly quota.

TODO: What happens if a PR is open and then more commits are added to it?