### PR TITLE
Add wrong argument eval error

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -18,6 +18,8 @@ pub enum EvalError {
     SymbolNotFound { symbol: String },
     #[error("Unexpected Value in the function name position.")]
     UnexpectedFunctionValue,
+    #[error("Wrong argument")]
+    WrongArgument { expected: String, received: String },
     #[error("Unhandled Error.")]
     UnhandledError,
 }
@@ -115,7 +117,7 @@ pub fn eval_list(list: &[Expr], env: Rc<Env>) -> Result<Rc<LispValue>, EvalError
 
             match func.as_deref() {
                 Ok(LispValue::Intrinsic(ref func)) => {
-                    let res = func(&arg_values);
+                    let res = func(&arg_values)?;
                     debug!("eval_list END Intrinsice {:?}", res);
                     Ok(res)
                 }
@@ -159,7 +161,7 @@ pub fn eval_atom(atom: &Atom, env: Rc<Env>) -> Result<Rc<LispValue>, EvalError> 
         Atom::Id(id) => match id.as_str() {
             "true" => Ok(Rc::new(LispValue::Bool(Bool::True))),
             "false" => Ok(Rc::new(LispValue::Bool(Bool::False))),
-            _ => env.get(&id).ok_or(EvalError::SymbolNotFound {
+            _ => env.get(id).ok_or(EvalError::SymbolNotFound {
                 symbol: id.to_string(),
             }),
         },

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use crate::eval::EvalError;
 use crate::lisp_value::{Bool, LispValue};
 
-// TODO: instead of defaulting to 0.0 we should return an error
 pub fn add(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
     let res = arguments
         .iter()
@@ -25,21 +24,20 @@ pub fn sub(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
 }
 
 pub fn eq(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
-    let first = &arguments[0];
-    for left_hand in arguments.iter().skip(1) {
-        if !first.eq(left_hand) {
-            return Ok(Rc::new(LispValue::Bool(Bool::False)));
-        }
-    }
-
-    Ok(Rc::new(LispValue::Bool(Bool::True)))
+	let first = arguments[0].get_number()?;
+    let res = arguments.iter().skip(1).try_fold(true, |acc, x| Ok(acc && first.eq(x.get_number()?)))?;
+	let lisp_result = match res {
+		false => Bool::False,
+		true => Bool::True,
+	};
+    Ok(Rc::new(LispValue::Bool(lisp_result)))
 }
 
 pub fn gt(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
-    let first = &arguments[0];
+    let first = arguments[0].get_number()?;
     for left_hand in arguments.iter().skip(1) {
-        match first.cmp(left_hand) {
-            Ordering::Greater => {}
+        match first.partial_cmp(left_hand.as_ref().get_number()?) {
+				Some(Ordering::Greater) => {}
             _ => return Ok(Rc::new(LispValue::Bool(Bool::False))),
         }
     }
@@ -47,10 +45,10 @@ pub fn gt(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
 }
 
 pub fn lt(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
-    let first = &arguments[0];
+    let first = arguments[0].get_number()?;
     for left_hand in arguments.iter().skip(1) {
-        match first.cmp(left_hand) {
-            Ordering::Less => {}
+        match first.partial_cmp(left_hand.as_ref().get_number()?) {
+            Some(Ordering::Less) => {}
             _ => return Ok(Rc::new(LispValue::Bool(Bool::False))),
         }
     }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -24,12 +24,15 @@ pub fn sub(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
 }
 
 pub fn eq(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
-	let first = arguments[0].get_number()?;
-    let res = arguments.iter().skip(1).try_fold(true, |acc, x| Ok(acc && first.eq(x.get_number()?)))?;
-	let lisp_result = match res {
-		false => Bool::False,
-		true => Bool::True,
-	};
+    let first = arguments[0].get_number()?;
+    let res = arguments
+        .iter()
+        .skip(1)
+        .try_fold(true, |acc, x| Ok(acc && first.eq(x.get_number()?)))?;
+    let lisp_result = match res {
+        false => Bool::False,
+        true => Bool::True,
+    };
     Ok(Rc::new(LispValue::Bool(lisp_result)))
 }
 
@@ -37,7 +40,7 @@ pub fn gt(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
     let first = arguments[0].get_number()?;
     for left_hand in arguments.iter().skip(1) {
         match first.partial_cmp(left_hand.as_ref().get_number()?) {
-				Some(Ordering::Greater) => {}
+            Some(Ordering::Greater) => {}
             _ => return Ok(Rc::new(LispValue::Bool(Bool::False))),
         }
     }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,57 +1,58 @@
 use std::cmp::Ordering;
 use std::rc::Rc;
 
+use crate::eval::EvalError;
 use crate::lisp_value::{Bool, LispValue};
 
 // TODO: instead of defaulting to 0.0 we should return an error
-pub fn add(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
+pub fn add(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
     let res = arguments
         .iter()
-        .fold(0.0, |acc, x| acc + x.get_number().unwrap_or(&0.0));
+        .try_fold(0.0, |acc, x| Ok(acc + x.get_number()?))?;
 
-    Rc::new(LispValue::Number(res))
+    Ok(Rc::new(LispValue::Number(res)))
 }
 
-pub fn sub(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
-    let first = arguments[0].get_number().unwrap_or(&0.0);
+pub fn sub(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
+    let first = arguments[0].get_number()?;
 
     let res = arguments
         .iter()
         .skip(1)
-        .fold(*first, |acc, x| acc - x.get_number().unwrap_or(&0.0));
+        .try_fold(*first, |acc, x| Ok(acc - x.get_number()?))?;
 
-    Rc::new(LispValue::Number(res))
+    Ok(Rc::new(LispValue::Number(res)))
 }
 
-pub fn eq(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
+pub fn eq(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
     let first = &arguments[0];
     for left_hand in arguments.iter().skip(1) {
         if !first.eq(left_hand) {
-            return Rc::new(LispValue::Bool(Bool::False));
+            return Ok(Rc::new(LispValue::Bool(Bool::False)));
         }
     }
 
-    Rc::new(LispValue::Bool(Bool::True))
+    Ok(Rc::new(LispValue::Bool(Bool::True)))
 }
 
-pub fn gt(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
+pub fn gt(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
     let first = &arguments[0];
     for left_hand in arguments.iter().skip(1) {
         match first.cmp(left_hand) {
             Ordering::Greater => {}
-            _ => return Rc::new(LispValue::Bool(Bool::False)),
+            _ => return Ok(Rc::new(LispValue::Bool(Bool::False))),
         }
     }
-    Rc::new(LispValue::Bool(Bool::True))
+    Ok(Rc::new(LispValue::Bool(Bool::True)))
 }
 
-pub fn lt(arguments: &[Rc<LispValue>]) -> Rc<LispValue> {
+pub fn lt(arguments: &[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError> {
     let first = &arguments[0];
     for left_hand in arguments.iter().skip(1) {
         match first.cmp(left_hand) {
             Ordering::Less => {}
-            _ => return Rc::new(LispValue::Bool(Bool::False)),
+            _ => return Ok(Rc::new(LispValue::Bool(Bool::False))),
         }
     }
-    Rc::new(LispValue::Bool(Bool::True))
+    Ok(Rc::new(LispValue::Bool(Bool::True)))
 }

--- a/src/lisp_value.rs
+++ b/src/lisp_value.rs
@@ -4,7 +4,10 @@ use std::rc::Rc;
 
 use crate::env::Env;
 
+use crate::eval::EvalError;
 use crate::Expr;
+
+type IntrinsicFunction = fn(&[Rc<LispValue>]) -> Result<Rc<LispValue>, EvalError>;
 
 #[derive(Clone)]
 pub enum LispValue {
@@ -13,16 +16,31 @@ pub enum LispValue {
     Id(String),
     Number(f64),
     Bool(Bool),
-    Intrinsic(fn(&[Rc<LispValue>]) -> Rc<LispValue>),
+    Intrinsic(IntrinsicFunction),
     Func(Func),
     StringValue(String),
 }
 
 impl LispValue {
-    pub fn get_number(&self) -> Option<&f64> {
+    pub fn get_number(&self) -> Result<&f64, EvalError> {
         match self {
-            LispValue::Number(ref num) => Some(num),
-            _ => None,
+            LispValue::Number(ref num) => Ok(num),
+            _ => Err(EvalError::WrongArgument {
+                expected: "Number".to_owned(),
+                received: self.to_string(),
+            }),
+        }
+    }
+
+    pub fn get_type(self) -> String {
+        match self {
+            LispValue::Nil => "Nil".to_owned(),
+            LispValue::Id(_) => "Identifier".to_owned(),
+            LispValue::Number(_) => "Number".to_owned(),
+            LispValue::Bool(_) => "Bool".to_owned(),
+            LispValue::Intrinsic(_) => "Intrinsic".to_owned(),
+            LispValue::Func(_) => "Function".to_owned(),
+            LispValue::StringValue(_) => "String".to_owned(),
         }
     }
 }


### PR DESCRIPTION
This PR adds a new kind of evaluation error that is generated when we try to use a native/intrinsic function with the wrong type of arguments like:
```scheme
(+ "hello" 3)
;; or
(- 3 5 "goodbye")
```